### PR TITLE
Fix composer complaining about the lock file not matching composer.json.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "f937c5470f4fa3d9774b934997ee2714",
+    "hash": "eabd9c2cac7f0a16be236202e6b14738",
     "packages": [
         {
             "name": "gitonomy/gitlib",
@@ -1535,7 +1535,9 @@
             "time": "2014-03-07 15:35:33"
         }
     ],
-    "aliases": [],
+    "aliases": [
+
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
         "phpbb/phpbb": 5,
@@ -1545,5 +1547,7 @@
     "platform": {
         "php": ">=5.3.3"
     },
-    "platform-dev": []
+    "platform-dev": [
+
+    ]
 }


### PR DESCRIPTION
Warning: The lock file is not up to date with the latest changes in
         composer.json. You may be getting outdated dependencies.
         Run update to update them.
