### PR TITLE
Using unserialize() should return an error

### DIFF
--- a/src/Tests/Tests/epv_test_validate_php_functions.php
+++ b/src/Tests/Tests/epv_test_validate_php_functions.php
@@ -478,6 +478,7 @@ class epv_test_validate_php_functions extends BaseTest
 			'var_dump'         => Output::ERROR,
 			'print_r'          => Output::ERROR,
 			'printf'           => Output::ERROR,
+			'unserialize'      => Output::ERROR,
 		);
 
 		foreach ($warn_array as $err => $level)


### PR DESCRIPTION
The function unserialize() is not safe to use with user input so therefore it should not be used in extensions.