### PR TITLE
Use semver to require the version of the Symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.3",
-        "symfony/yaml": ">=2.3,<2.7",
-        "symfony/console": ">=2.3,<2.7",
-        "symfony/finder": ">=2.3,<2.7",
-        "symfony/process": ">=2.3,<2.7",
+        "symfony/yaml": "^2.3",
+        "symfony/console": "^2.3",
+        "symfony/finder": "^2.3",
+        "symfony/process": "^2.3",
         "nikic/php-parser": "0.9.*@dev",
         "gitonomy/gitlib": "0.1.*@dev",
         "sensiolabs/ansi-to-html": "~1.1"

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.3",
-        "symfony/yaml": "^2.3",
-        "symfony/console": "^2.3",
-        "symfony/finder": "^2.3",
-        "symfony/process": "^2.3",
+        "symfony/yaml": "~2.3",
+        "symfony/console": "~2.3",
+        "symfony/finder": "~2.3",
+        "symfony/process": "~2.3",
         "nikic/php-parser": "0.9.*@dev",
         "gitonomy/gitlib": "0.1.*@dev",
         "sensiolabs/ansi-to-html": "~1.1"


### PR DESCRIPTION
2.3,<2.7 is too restrictive and it disallow 2.8 even if it is compatible due to the BC promise. This prevent EPV to be installed along phpBB 3.2