### PR TITLE
Require a . after the event naming.

### DIFF
--- a/src/Tests/Tests/epv_test_validate_event_names.php
+++ b/src/Tests/Tests/epv_test_validate_event_names.php
@@ -43,7 +43,9 @@ class epv_test_validate_event_names extends BaseTest
 		}
 
 		$events = $exporter->get_events();
-		$vendor = strtolower(str_replace('/', '.', $this->namespace)) + '.'; // event names are requierd to be lowercase!
+		// event names are requierd to be lowercase
+		// event names should end with a dot to seperate the vendor.name and the actual event name.
+		$vendor = strtolower(str_replace('/', '.', $this->namespace)) + '.'; 
 
 		foreach ($events as $event)
 		{
@@ -67,6 +69,6 @@ class epv_test_validate_event_names extends BaseTest
 
 	public function testName()
 	{
-		return "Validate directory structure";
+		return "test even names";
 	}
 }

--- a/src/Tests/Tests/epv_test_validate_event_names.php
+++ b/src/Tests/Tests/epv_test_validate_event_names.php
@@ -43,7 +43,8 @@ class epv_test_validate_event_names extends BaseTest
 		}
 
 		$events = $exporter->get_events();
-		$vendor = strtolower(str_replace('/', '.', $this->namespace)); // event names are requierd to be lowercase!
+		$this->output->inMaxPogress(sizeof($events) * 3);
+		$vendor = strtolower(str_replace('/', '.', $this->namespace)) + '.'; // event names are requierd to be lowercase!
 
 		foreach ($events as $event)
 		{

--- a/src/Tests/Tests/epv_test_validate_event_names.php
+++ b/src/Tests/Tests/epv_test_validate_event_names.php
@@ -43,7 +43,7 @@ class epv_test_validate_event_names extends BaseTest
 		}
 
 		$events = $exporter->get_events();
-		// event names are requierd to be lowercase
+		// event names are required to be lowercase
 		// event names should end with a dot to seperate the vendor.name and the actual event name.
 		$vendor = strtolower(str_replace('/', '.', $this->namespace)) + '.'; 
 

--- a/src/Tests/Tests/epv_test_validate_event_names.php
+++ b/src/Tests/Tests/epv_test_validate_event_names.php
@@ -69,6 +69,6 @@ class epv_test_validate_event_names extends BaseTest
 
 	public function testName()
 	{
-		return "test even names";
+		return "test event names";
 	}
 }

--- a/src/Tests/Tests/epv_test_validate_event_names.php
+++ b/src/Tests/Tests/epv_test_validate_event_names.php
@@ -43,7 +43,6 @@ class epv_test_validate_event_names extends BaseTest
 		}
 
 		$events = $exporter->get_events();
-		$this->output->inMaxPogress(sizeof($events) * 3);
 		$vendor = strtolower(str_replace('/', '.', $this->namespace)) + '.'; // event names are requierd to be lowercase!
 
 		foreach ($events as $event)

--- a/src/Tests/Tests/epv_test_validate_event_names.php
+++ b/src/Tests/Tests/epv_test_validate_event_names.php
@@ -69,6 +69,6 @@ class epv_test_validate_event_names extends BaseTest
 
 	public function testName()
 	{
-		return "test event names";
+		return "Test event names";
 	}
 }


### PR DESCRIPTION
This will prevent something like vendor.name_event_name (Which should be vendor.name.event_name)