### PR TITLE
Add potential SQL injection validator

### DIFF
--- a/src/Tests/Tests/epv_test_validate_sql_queries.php
+++ b/src/Tests/Tests/epv_test_validate_sql_queries.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ *
+ * EPV :: The phpBB Forum Extension Pre Validator.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license       GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+namespace Phpbb\Epv\Tests\Tests;
+
+
+use Phpbb\Epv\Files\FileInterface;
+use Phpbb\Epv\Files\Type\PHPFileInterface;
+use Phpbb\Epv\Output\Output;
+use Phpbb\Epv\Output\OutputInterface;
+use Phpbb\Epv\Tests\BaseTest;
+use Phpbb\Epv\Tests\Exception\TestException;
+use Phpbb\Epv\Tests\Type;
+
+
+class epv_test_validate_sql_queries extends BaseTest
+{
+	/**
+	 * Allowed keywords
+	 * 
+	 * If line contains one of these keywords, ignore it even when it
+	 * has been matched with regular expression.
+	 *
+	 * @var array
+	 */
+	protected $allowed_keywords = array(
+		'sql_in_set',
+		'sql_escape',
+		'sql_bit_and',
+		'get_visibility_sql',
+		'get_sql_where',
+		'get_forums_visibility_sql',
+		'ORDER BY',
+		'ORDER_BY',
+	);
+
+	/**
+	 * @param bool            $debug if debug is enabled
+	 * @param OutputInterface $output
+	 * @param string          $basedir
+	 * @param string          $namespace
+	 * @param boolean         $titania
+	 * @param string          $opendir
+	 */
+	public function __construct($debug, OutputInterface $output, $basedir, $namespace, $titania, $opendir)
+	{
+		parent::__construct($debug, $output, $basedir, $namespace, $titania, $opendir);
+
+		$this->fileTypeFull   = Type::TYPE_PHP;
+	}
+
+	/**
+	 * @param FileInterface $file
+	 *
+	 * @throws \Phpbb\Epv\Tests\Exception\TestException
+	 */
+	public function validateFile(FileInterface $file)
+	{
+		if (!$file instanceof PHPFileInterface)
+		{
+			throw new TestException('This test expects a php type, but found something else.');
+		}
+		$code = $file->getFile();
+		$code_exploded = explode("\n", $code);
+
+		if (preg_match_all('/WHERE[^;\$]+[=<>]+[^;]+("|\') \. \$/mU', $code, $matches, PREG_OFFSET_CAPTURE))
+		{
+			foreach ($matches[0] as $match)
+			{
+				$prelines = substr_count($code, "\n", 0, $match[1]);
+				$inlines = substr_count($match[0], "\n");
+				$line = $prelines + $inlines;
+
+				$test = array_reduce($this->allowed_keywords, function($acc, $keyword) use ($code_exploded, $line) {
+					return $acc || strpos($code_exploded[$line], $keyword) !== false;
+				}, false);
+				if ($test)
+				{
+					continue;
+				}
+
+				$this->output->addMessage(Output::WARNING, sprintf('Found potential SQL injection on line %s in %s', $line + 1, $file->getSaveFilename()));
+			}
+		}
+	}
+
+	/**
+	 *
+	 * @return String
+	 */
+	public function testName()
+	{
+		return 'Validate SQL queries';
+	}
+}

--- a/tests/testFiles/sql_injection.php
+++ b/tests/testFiles/sql_injection.php
@@ -1,0 +1,9 @@
+<?php
+
+$sql = 'SELECT *
+	FROM phpbb_posts
+	WHERE post_id = ' . $post_id;
+
+$sql = "SELECT *
+	FROM phpbb_topics
+	WHERE topic_title = '" . $this->db->sql_escape($topic_title) . "'";

--- a/tests/validate_sql_queries_test.php
+++ b/tests/validate_sql_queries_test.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ *
+ * EPV :: The phpBB Forum Extension Pre Validator.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+class validate_sql_queries_test extends PHPUnit_Framework_TestCase
+{
+	public static function setUpBeforeClass()
+	{
+		require_once('./tests/Mock/Output.php');
+	}
+	
+	public function test_insecure_sql_query() {
+		$output = $this->getMock('Phpbb\Epv\Output\OutputInterface');
+		$output->expects($this->once())
+			->method('addMessage')
+			->with(\Phpbb\Epv\Output\OutputInterface::WARNING, 'Found potential SQL injection on line 5 in tests/testFiles/sql_injectionphp')
+		;
+
+		$file_loader = new \Phpbb\Epv\Files\FileLoader(new \Phpbb\Epv\Tests\Mock\Output(), false, '.', '.');
+		$file = $file_loader->loadFile('tests/testFiles/sql_injection.php');
+
+		$tester = new \Phpbb\Epv\Tests\Tests\epv_test_validate_sql_queries(false, $output, '/a/b/', 'epv/test', false, '/a/');
+		$tester->validateFile($file);
+	}
+}


### PR DESCRIPTION
This PR adds a new validator which tries to find potential SQL injection entry points. What it does is basically find all SQL queries, where a `WHERE` clause contains a PHP variable which is not casted to `(int)`, or `sql_escape`-d.

Note, that in order to prevent false positives, there are edge cases that are omitted, like `WHERE forum_id = $from_id";`. Extension validators should check all SQL queries manually during the validation.