### PR TITLE
Improved error handling when importing invalid & empty YML files

### DIFF
--- a/src/Files/Type/YmlFile.php
+++ b/src/Files/Type/YmlFile.php
@@ -27,7 +27,7 @@ class YmlFile extends BaseFile implements YmlFileInterface
 
 		try
 		{
-			$content = Yaml::parse($this->fileData);
+			$content = (array) Yaml::parse($this->fileData);
 
 			// Look for imports
 			if (isset($content['imports']) && is_array($content['imports']))

--- a/src/Files/Type/YmlFile.php
+++ b/src/Files/Type/YmlFile.php
@@ -27,7 +27,12 @@ class YmlFile extends BaseFile implements YmlFileInterface
 
 		try
 		{
-			$content = (array) Yaml::parse($this->fileData);
+			$content = Yaml::parse($this->fileData);
+
+			if (!is_array($content))
+			{
+				throw new ParseException("Empty file");
+			}
 
 			// Look for imports
 			if (isset($content['imports']) && is_array($content['imports']))
@@ -40,9 +45,18 @@ class YmlFile extends BaseFile implements YmlFileInterface
 				{
 					if (isset($import['resource']))
 					{
-						$importYmlFileName = $dirname . '/' . $import['resource'];
-						$importYmlFile = new YmlFile($debug, $importYmlFileName, $rundir);
-						$extraContent = $importYmlFile->getYaml();
+						try
+						{
+							$importYmlFileName = $dirname . '/' . $import['resource'];
+							$importYmlFile = new YmlFile($debug, $importYmlFileName, $rundir);
+							$extraContent = $importYmlFile->getYaml();
+						}
+						catch (FileLoadException $ex)
+						{
+							// The imported yml file will be loaded individually later.
+							// Let's avoid duplicate error messages here and continue with the current yml.
+							$extraContent = array();
+						}
 
 						// Imports are at the top of the yaml file, so these should be loaded first.
 						// The values of the current yaml file will overwrite existing array values of the imports.

--- a/tests/file_loader_test.php
+++ b/tests/file_loader_test.php
@@ -8,29 +8,62 @@
  *
  */
 
+use Phpbb\Epv\Files\FileLoader;
+use Phpbb\Epv\Files\Type\LangFile;
+use Phpbb\Epv\Files\Type\MigrationFile;
+use Phpbb\Epv\Files\Type\PHPFile;
+use Phpbb\Epv\Files\Type\PHPFileInterface;
+use Phpbb\Epv\Files\Type\YmlFile;
+use Phpbb\Epv\Tests\Mock\Output;
+
 class file_loader_test extends PHPUnit_Framework_TestCase {
+
+	/** @var FileLoader */
+	private static $loader;
+
 	public static function setUpBeforeClass()
 	{
 		require_once('./tests/Mock/Output.php');
-	}
 
-	private function getLoader()
-	{
-		return $file = new \Phpbb\Epv\Files\FileLoader(new \Phpbb\Epv\Tests\Mock\Output(), false, 'tests/testFiles/', '.');
+		static::$loader = new FileLoader(new Output(), false, 'tests/testFiles/', '.');
 	}
 
 	public function test_file_php() {
-		$file = $this->getLoader();
 
-		$type = $file->loadFile('tests/testFiles/test.txt.php');
-		$typePhp = $file->loadFile('tests/testFiles/test.php');
-		$typeMigration = $file->loadFile('tests/testFiles/migrations/test.php');
+		$type = static::$loader->loadFile('tests/testFiles/test.txt.php');
+		$typePhp = static::$loader->loadFile('tests/testFiles/test.php');
+		$typeMigration = static::$loader->loadFile('tests/testFiles/migrations/test.php');
 
-		$this->assertTrue($type instanceof \Phpbb\Epv\Files\Type\PHPFile);
-		$this->assertTrue($typePhp instanceof \Phpbb\Epv\Files\Type\PHPFile);
-		$this->assertFalse($typePhp instanceof \Phpbb\Epv\Files\Type\MigrationFile);
-		$this->assertFalse($typePhp instanceof \Phpbb\Epv\Files\Type\LangFile);
-		$this->assertTrue($typeMigration instanceof \Phpbb\Epv\Files\Type\PHPFileInterface); // It extends from the interface!
-		$this->assertTrue($typeMigration instanceof \Phpbb\Epv\Files\Type\MigrationFile, 'type is migration file');
+		$this->assertTrue($type instanceof PHPFile);
+		$this->assertTrue($typePhp instanceof PHPFile);
+		$this->assertFalse($typePhp instanceof MigrationFile);
+		$this->assertFalse($typePhp instanceof LangFile);
+		$this->assertTrue($typeMigration instanceof PHPFileInterface); // It extends from the interface!
+		$this->assertTrue($typeMigration instanceof MigrationFile, 'type is migration file');
+	}
+
+	public function test_file_yml()
+	{
+		$validYml = static::$loader->loadFile('tests/testFiles/valid.yml');
+		$invalidImportYml = static::$loader->loadFile('tests/testFiles/invalid_import.yml');
+		$emptyImportYml = static::$loader->loadFile('tests/testFiles/empty_import.yml');
+
+		$this->assertTrue($validYml instanceof YmlFile);
+		$this->assertTrue($invalidImportYml instanceof YmlFile);
+		$this->assertTrue($emptyImportYml instanceof YmlFile);
+	}
+
+	public function test_file_invalid_yml()
+	{
+		$this->setExpectedException(Exception::class);
+		$invalidYml = static::$loader->loadFile('tests/testFiles/invalid.yml');
+		$this->assertNull($invalidYml);
+	}
+
+	public function test_file_empty_yml()
+	{
+		$this->setExpectedException(Exception::class);
+		$emptyYml = static::$loader->loadFile('tests/testFiles/empty.yml');
+		$this->assertNull($emptyYml);
 	}
 }

--- a/tests/testFiles/empty_import.yml
+++ b/tests/testFiles/empty_import.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: empty.yml }
+
+services:
+    some.service.name:
+        class: a\b\c

--- a/tests/testFiles/invalid.yml
+++ b/tests/testFiles/invalid.yml
@@ -1,0 +1,2 @@
+services:
+	some.

--- a/tests/testFiles/invalid_import.yml
+++ b/tests/testFiles/invalid_import.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: invalid.yml }
+
+services:
+    some.service.name:
+        class: a\b\c

--- a/tests/testFiles/valid.yml
+++ b/tests/testFiles/valid.yml
@@ -1,0 +1,3 @@
+services:
+    some.service.name:
+        class: a\b\c


### PR DESCRIPTION
When importing an empty yml file, [`Yaml::parse` returns `null`](https://github.com/phpbb/epv/blob/d2fc4e022f06512c4205551fb04bcfd2cdc9fedf/src/Files/Type/YmlFile.php#L30) which is later [passed as first argument to `array_replace_recursive`.](https://github.com/phpbb/epv/blob/d2fc4e022f06512c4205551fb04bcfd2cdc9fedf/src/Files/Type/YmlFile.php#L49) This results in the contents of the importing yml file (`services.yml` for example) to be empty, which causes wrong warning/error messages when running tests on it.

To fix this, a simple `(array)` cast should do. This will force a return value of `null` to an empty array, making `array_replace_recursive` work again.