### PR TITLE
Fixed checking for missing revert_schema() method

### DIFF
--- a/src/Tests/Tests/epv_test_validate_revert_schema.php
+++ b/src/Tests/Tests/epv_test_validate_revert_schema.php
@@ -20,6 +20,7 @@ use PhpParser\Error;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\ParserFactory;
 
 class epv_test_validate_revert_schema extends BaseTest
@@ -78,11 +79,16 @@ class epv_test_validate_revert_schema extends BaseTest
 	 */
 	protected function isMissingRevertSchema($nodes)
 	{
-		foreach ($nodes as $node)
+		$root = reset($nodes);
+
+		if ($root instanceof Namespace_)
 		{
-			if ($node instanceof Class_ && $this->hasMethod($node, 'update_schema') && !$this->hasMethod($node, 'revert_schema'))
+			foreach ($root->stmts as $node)
 			{
-				return true;
+				if ($node instanceof Class_ && $this->hasMethod($node, 'update_schema') && !$this->hasMethod($node, 'revert_schema'))
+				{
+					return true;
+				}
 			}
 		}
 

--- a/tests/testFiles/migrations/existing_revert_schema.php
+++ b/tests/testFiles/migrations/existing_revert_schema.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace epv\test\migrations;
+
 class existing_revert_schema_migration extends \phpbb\db\migration\migration
 {
 	public function update_schema()

--- a/tests/testFiles/migrations/missing_revert_schema.php
+++ b/tests/testFiles/migrations/missing_revert_schema.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace epv\test\migrations;
+
 class missing_revert_schema_migration extends \phpbb\db\migration\migration
 {
 	public function update_schema()

--- a/tests/testFiles/migrations/missing_update_schema.php
+++ b/tests/testFiles/migrations/missing_update_schema.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace epv\test\migrations;
+
 class missing_update_schema_migration extends \phpbb\db\migration\migration
 {
 	public function dummy()


### PR DESCRIPTION
Extension migrations are required to have a namespace. The PHP parser's node list nests the optional `use` and `class` nodes inside the `namespace` node, rather than returning a flat list of 3 nodes, which the current code is expecting, and therefore it never finds the `class` node to run the test on. This PR is fixing that.