### PR TITLE
Kindly Check for following Err0r.

### DIFF
--- a/src/Tests/Tests/epv_test_validate_languages.php
+++ b/src/Tests/Tests/epv_test_validate_languages.php
@@ -58,7 +58,7 @@ class epv_test_validate_languages extends BaseTest
 
 		foreach ($files as $file)
 		{
-			if (preg_match('#^' . $this->basedir . 'language/([a-z_]+?)/(.+\.php)$#', $file, $matches) === 1)
+			if (preg_match('#^' . $this->basedir . '\language/([a-z_]+?)/(.+\.php)$#', $file, $matches) === 1)
 			{
 				$language = $matches[1]; // language, e.g. "en"
 				$relative_filename = $matches[2]; // file name relative to language's base dir, e.g. "info_acp_ext.php"


### PR DESCRIPTION
Geting Err0r :    
```
PHP Warning:  preg_match(): Compilation failed: PCRE does not support \L, \l, \N{name}, \U, or \u at offset 54 in C:\XAMPP\htdocs\vendor\phpbb\epv\src\Tests\Tests\epv_test_validate_languages.php on line 61

Warning: preg_match(): Compilation failed: PCRE does not support \L, \l, \N{name}, \U, or \u at offset 54 in C:\XAMPP\htdocs\vendor\phpbb\epv\src\Tests\Tests\epv_test_validate_languages.php on line 61
```

but doing this : from `'language/` to `'\language/`
then it does not give above Err0r,
on localhost, Windows, XAMPP.

Installed in `C:\XAMPP\htdocs\vendor\phpbb\`