### PR TITLE
Fixed file path in exception message

### DIFF
--- a/src/Tests/Tests/epv_test_validate_languages.php
+++ b/src/Tests/Tests/epv_test_validate_languages.php
@@ -74,7 +74,7 @@ class epv_test_validate_languages extends BaseTest
 				}
 				catch (Error $e)
 				{
-					$this->output->addMessage(OutputInterface::FATAL, 'PHP parse error in file ' . $file->getSaveFilename() . '. Message: ' . $e->getMessage());
+					$this->output->addMessage(OutputInterface::FATAL, 'PHP parse error in file ' . str_replace($this->basedir, '', $file) . '. Message: ' . $e->getMessage());
 				}
 			}
 		}


### PR DESCRIPTION
The method's `$files` parameter is an array of strings.