### PR TITLE
Scan all array literals for language keys

### DIFF
--- a/src/Tests/ArrayKeyVisitor.php
+++ b/src/Tests/ArrayKeyVisitor.php
@@ -37,9 +37,9 @@ class ArrayKeyVisitor extends NodeVisitorAbstract
 	 */
 	public function enterNode(Node $node)
 	{
-        if ($node instanceof Array_)
+		if ($node instanceof Array_)
 		{
-            foreach ($node->items as $item)
+			foreach ($node->items as $item)
 			{
 				/** @var ArrayItem $item */
 				if ($item->key instanceof String_)
@@ -47,13 +47,13 @@ class ArrayKeyVisitor extends NodeVisitorAbstract
 					$this->keys[] = $item->key->value;
 				}
 			}
-        }
-    }
+		}
+	}
 
 	/**
 	 * @return array
 	 */
-    public function get_array_keys()
+	public function get_array_keys()
 	{
 		return $this->keys;
 	}

--- a/src/Tests/ArrayKeyVisitor.php
+++ b/src/Tests/ArrayKeyVisitor.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ *
+ * EPV :: The phpBB Forum Extension Pre Validator.
+ *
+ * @copyright (c) 2014 phpBB Limited <https://www.phpbb.com>
+ * @license       GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+namespace Phpbb\Epv\Tests;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+
+class ArrayKeyVisitor extends NodeVisitorAbstract
+{
+	/**
+	 * @var array
+	 */
+	private $keys;
+
+	/**
+	 * @param array $nodes
+	 * @return void|null|Node[]
+	 */
+	public function beforeTraverse(array $nodes)
+	{
+		$this->keys = [];
+	}
+
+	/**
+	 * @param Node $node
+	 * @return void|null|int|Node
+	 */
+	public function enterNode(Node $node)
+	{
+        if ($node instanceof Array_)
+		{
+            foreach ($node->items as $item)
+			{
+				/** @var ArrayItem $item */
+				if ($item->key instanceof String_)
+				{
+					$this->keys[] = $item->key->value;
+				}
+			}
+        }
+    }
+
+	/**
+	 * @return array
+	 */
+    public function get_array_keys()
+	{
+		return $this->keys;
+	}
+}

--- a/src/Tests/Tests/epv_test_validate_languages.php
+++ b/src/Tests/Tests/epv_test_validate_languages.php
@@ -22,8 +22,8 @@ use PhpParser\ParserFactory;
 class epv_test_validate_languages extends BaseTest
 {
 	/**
-     * @var Parser
-     */
+	 * @var Parser
+	 */
 	private $parser;
 
 	/**

--- a/tests/testFiles/language/en/common.php
+++ b/tests/testFiles/language/en/common.php
@@ -13,4 +13,8 @@ if (empty($lang) || !is_array($lang))
 $lang = array_merge($lang, array(
 	'A' => 'First language string',
 	'B' => 'Second language string',
+	'C' => [
+		1 => 'Singular',
+		2 => 'Plural',
+	],
 ));

--- a/tests/testFiles/language/en_complete/common.php
+++ b/tests/testFiles/language/en_complete/common.php
@@ -14,6 +14,8 @@ $lang = array_merge($lang, array(
 	'A' => 'First language string',
 ));
 
-$lang = array_merge($lang, array(
+$b = array(
 	'B' => 'Second language string',
-));
+);
+
+$lang = array_merge($lang, $b);

--- a/tests/testFiles/language/en_complete/common.php
+++ b/tests/testFiles/language/en_complete/common.php
@@ -18,4 +18,9 @@ $b = array(
 	'B' => 'Second language string',
 );
 
-$lang = array_merge($lang, $b);
+$lang = array_merge($lang, $b, [
+	'C' => [
+		// Missing plural should not generate an error
+		1 => 'Singular',
+	],
+]);

--- a/tests/testFiles/language/en_incomplete/common.php
+++ b/tests/testFiles/language/en_incomplete/common.php
@@ -12,4 +12,8 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, array(
 	'A' => 'First language string',
+	'C' => [
+		1 => 'Singular',
+		2 => 'Plural',
+	],
 ));


### PR DESCRIPTION
Instead of extracting language keys only from arguments to `array_merge()`, with this change, string keys from _all array literals in the file_ will be collected and interpreted as being language keys.