### PR TITLE
fixup Error: Packaging structure doesn't meet the extension DB policies.  when use --dir param

### DIFF
--- a/src/Tests/Tests/epv_test_validate_directory_structure.php
+++ b/src/Tests/Tests/epv_test_validate_directory_structure.php
@@ -73,7 +73,7 @@ class epv_test_validate_directory_structure extends BaseTest
 						$this->output->addMessage(Output::WARNING, 'The name of composer.json should be completely lowercase.');
 					}
 					$sp    = str_replace('\\', '/', $dir);
-					$sp    = str_replace(str_replace('\\', '/', $this->opendir), '', $sp);
+					$sp    = str_replace(str_replace('\\', '/', dirname(dirname($this->opendir))), '', $sp);
 					$sp    = str_replace('/composer.json', '', $sp);
 
 					if (!empty($sp) && $sp[0] == '/')


### PR DESCRIPTION
fixup Error: Packaging structure doesn't meet the extension DB policies.  when use --dir param

run:
```bash
cd my-extension-dir
php PATH-TO/epv/src/EPV.php run --dir .
```

expected:
no error

the situation:
```Test results for extension:
Error: Packaging structure doesn't meet the extension DB policies.
Expected: vendor/my-extension-name
Got: 
```