### PR TITLE
Add check for existence of en language pack

### DIFF
--- a/src/Tests/Tests/epv_test_validate_languages.php
+++ b/src/Tests/Tests/epv_test_validate_languages.php
@@ -79,7 +79,7 @@ class epv_test_validate_languages extends BaseTest
 			}
 		}
 
-		if (!array_key_exists('en', $langs))
+		if (!empty($langs) && !array_key_exists('en', $langs))
 		{
 			$this->output->addMessage(OutputInterface::FATAL, sprintf("English language pack is missing"));
 		}

--- a/src/Tests/Tests/epv_test_validate_languages.php
+++ b/src/Tests/Tests/epv_test_validate_languages.php
@@ -79,6 +79,11 @@ class epv_test_validate_languages extends BaseTest
 			}
 		}
 
+		if (!array_key_exists('en', $langs))
+		{
+			$this->output->addMessage(OutputInterface::FATAL, sprintf("English language pack is missing"));
+		}
+
 		foreach ($langs as $lang_name => $file_contents)
 		{
 			// Check for missing language files

--- a/src/Tests/Tests/epv_test_validate_languages.php
+++ b/src/Tests/Tests/epv_test_validate_languages.php
@@ -81,7 +81,7 @@ class epv_test_validate_languages extends BaseTest
 
 		if (!empty($langs) && !array_key_exists('en', $langs))
 		{
-			$this->output->addMessage(OutputInterface::FATAL, sprintf("English language pack is missing"));
+			$this->output->addMessage(OutputInterface::FATAL, 'English language pack is missing');
 		}
 
 		foreach ($langs as $lang_name => $file_contents)


### PR DESCRIPTION
Currently EPV does not check whether an extension has an English language pack, since English is the default and fallback language a missing "en" language pack should throw an error.
This PR adds check to do exactly that