### PR TITLE
Process simple dispatcher events too

### DIFF
--- a/src/Events/php_exporter.php
+++ b/src/Events/php_exporter.php
@@ -119,10 +119,13 @@ class php_exporter
 					$event_line = $i;
 					$this->set_current_event($this->get_event_name($event_line, false), $event_line);
 
-					// Find variables of the event
-					$arguments = $this->get_vars_from_array();
-					$doc_vars  = $this->get_vars_from_docblock();
-					$this->validate_vars_docblock_array($arguments, $doc_vars);
+					// Find variables of the event if it has them
+					if (strpos($this->file_lines[$event_line], 'compact('))
+					{
+						$arguments = $this->get_vars_from_array();
+						$doc_vars  = $this->get_vars_from_docblock();
+						$this->validate_vars_docblock_array($arguments, $doc_vars);
+					}
 				}
 				else
 				{

--- a/src/Events/php_exporter.php
+++ b/src/Events/php_exporter.php
@@ -197,7 +197,8 @@ class php_exporter
 			$regex = '#(?:extract\(\$([a-z](?:[a-z0-9_]|->)*)';
 			$regex .= '->trigger_event\(';
 			$regex .= '\'(?\'event1\'%1$s)\'';
-			$regex .= ', compact\(\$vars\)\)\)|\$([a-z](?:[a-z0-9_]|->)*)';
+			$regex .= ', compact\(\$vars\)\)\)';
+			$regex .= '|\$([a-z](?:[a-z0-9_]|->)*)';
 			$regex .= '->trigger_event\(';
 			$regex .= '\'(?\'event2\'%1$s)\'';
 			$regex .= '\));#';

--- a/tests/events/invalid_name_simple.php
+++ b/tests/events/invalid_name_simple.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Modify the data for post submitting
+ *
+ * @event rxu.postsmerging.posts_merging_end
+ * @since 2.0.0
+ */
+$phpbb_dispatcher->trigger_event('rxu.PostsMerging.posts_merging_end');

--- a/tests/events/invalid_name_simple_dispatch.php
+++ b/tests/events/invalid_name_simple_dispatch.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Modify the data for post submitting
+ *
+ * @event rxu.postsmerging.posts_merging_end
+ * @since 2.0.0
+ */
+$phpbb_dispatcher->dispatch('rxu.PostsMerging.posts_merging_end');

--- a/tests/events/valid_name_simple.php
+++ b/tests/events/valid_name_simple.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Modify the data for post submitting
+ *
+ * @event rxu.postsmerging.posts_merging_end
+ * @since 2.0.0
+ */
+$phpbb_dispatcher->trigger_event('rxu.postsmerging.posts_merging_end');

--- a/tests/events/valid_name_simple_dispatch.php
+++ b/tests/events/valid_name_simple_dispatch.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Modify the data for post submitting
+ *
+ * @event rxu.postsmerging.posts_merging_end
+ * @since 2.0.0
+ */
+$phpbb_dispatcher->dispatch('rxu.postsmerging.posts_merging_end');

--- a/tests/php_exporter_test.php
+++ b/tests/php_exporter_test.php
@@ -52,15 +52,16 @@ class php_exporter_test extends TestCase
 	/**
 	 * @dataProvider extension_data
 	 */
-	public function test_event_name($line, $content, $is_dispatch, $expected_name, $expected_vars, $expected_errors = [])
+	public function test_event_name($line, $file, $is_dispatch, $expected_name, $expected_vars, $expected_errors = [])
 	{
+		$content = file_get_contents($file);
 		$output   = new Output();
 		$exporter = new php_exporter($output, '');
-		$exporter->set_content(explode("\n", file_get_contents($content)));
+		$exporter->set_content(explode("\n", $content));
 
 		$name = $exporter->get_event_name($line, $is_dispatch);
 		$exporter->set_current_event($name, $line);
-		$vars = $expected_vars ? $exporter->get_vars_from_array(false) : [];
+		$vars = strpos($content, 'compact(') ? $exporter->get_vars_from_array(false) : [];
 
 		self::assertEquals($expected_name, $name);
 		self::assertEquals($expected_vars, $vars);

--- a/tests/php_exporter_test.php
+++ b/tests/php_exporter_test.php
@@ -34,29 +34,31 @@ class php_exporter_test extends TestCase
 		];
 
 		return [
-			[27, './tests/events/invalid_name_long_multi.php', 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
-			[17, './tests/events/invalid_name_long_single.php', 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
-			[27, './tests/events/invalid_name_short_multi.php', 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
-			[17, './tests/events/invalid_name_short_single.php', 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
-			[7, './tests/events/invalid_name_simple.php', 'rxu.PostsMerging.posts_merging_end', [], $expected_errors],
-			[27, './tests/events/valid_name_long_multi.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
-			[17, './tests/events/valid_name_long_single.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
-			[27, './tests/events/valid_name_short_multi.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
-			[17, './tests/events/valid_name_short_single.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
-			[7, './tests/events/valid_name_simple.php', 'rxu.postsmerging.posts_merging_end', []],
+			[27, './tests/events/invalid_name_long_multi.php', false, 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
+			[17, './tests/events/invalid_name_long_single.php', false, 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
+			[27, './tests/events/invalid_name_short_multi.php', false, 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
+			[17, './tests/events/invalid_name_short_single.php', false, 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
+			[7, './tests/events/invalid_name_simple.php', false, 'rxu.PostsMerging.posts_merging_end', [], $expected_errors],
+			[7, './tests/events/invalid_name_simple_dispatch.php', true, 'rxu.PostsMerging.posts_merging_end', [], $expected_errors],
+			[27, './tests/events/valid_name_long_multi.php', false, 'rxu.postsmerging.posts_merging_end', $expected_vars],
+			[17, './tests/events/valid_name_long_single.php', false, 'rxu.postsmerging.posts_merging_end', $expected_vars],
+			[27, './tests/events/valid_name_short_multi.php', false, 'rxu.postsmerging.posts_merging_end', $expected_vars],
+			[17, './tests/events/valid_name_short_single.php', false, 'rxu.postsmerging.posts_merging_end', $expected_vars],
+			[7, './tests/events/valid_name_simple.php', false, 'rxu.postsmerging.posts_merging_end', []],
+			[7, './tests/events/valid_name_simple_dispatch.php', true, 'rxu.postsmerging.posts_merging_end', []],
 		];
 	}
 
 	/**
 	 * @dataProvider extension_data
 	 */
-	public function test_event_name($line, $content, $expected_name, $expected_vars, $expected_errors = [])
+	public function test_event_name($line, $content, $is_dispatch, $expected_name, $expected_vars, $expected_errors = [])
 	{
 		$output   = new Output();
 		$exporter = new php_exporter($output, '');
 		$exporter->set_content(explode("\n", file_get_contents($content)));
 
-		$name = $exporter->get_event_name($line, false);
+		$name = $exporter->get_event_name($line, $is_dispatch);
 		$exporter->set_current_event($name, $line);
 		$vars = $expected_vars ? $exporter->get_vars_from_array(false) : [];
 

--- a/tests/php_exporter_test.php
+++ b/tests/php_exporter_test.php
@@ -38,10 +38,12 @@ class php_exporter_test extends TestCase
 			[17, './tests/events/invalid_name_long_single.php', 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
 			[27, './tests/events/invalid_name_short_multi.php', 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
 			[17, './tests/events/invalid_name_short_single.php', 'rxu.PostsMerging.posts_merging_end', $expected_vars, $expected_errors],
+			[7, './tests/events/invalid_name_simple.php', 'rxu.PostsMerging.posts_merging_end', [], $expected_errors],
 			[27, './tests/events/valid_name_long_multi.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
 			[17, './tests/events/valid_name_long_single.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
 			[27, './tests/events/valid_name_short_multi.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
 			[17, './tests/events/valid_name_short_single.php', 'rxu.postsmerging.posts_merging_end', $expected_vars],
+			[7, './tests/events/valid_name_simple.php', 'rxu.postsmerging.posts_merging_end', []],
 		];
 	}
 
@@ -56,7 +58,7 @@ class php_exporter_test extends TestCase
 
 		$name = $exporter->get_event_name($line, false);
 		$exporter->set_current_event($name, $line);
-		$vars = $exporter->get_vars_from_array(false);
+		$vars = $expected_vars ? $exporter->get_vars_from_array(false) : [];
 
 		self::assertEquals($expected_name, $name);
 		self::assertEquals($expected_vars, $vars);


### PR DESCRIPTION
EPV was not recognizing `trigger_event('foo')` which is allowed (no extract/compact/$vars stuff).

So now it can validate:
`->trigger_event('foo', compact($vars)));`
`->trigger_event('foo');`
`->dispatch('foo');`